### PR TITLE
Allow for transferring of content between different IPFS networks

### DIFF
--- a/beam/README.md
+++ b/beam/README.md
@@ -1,0 +1,3 @@
+# beam
+
+`beam` is used to transfer ipfs content across different networks. An example usage is to transfer files between two different private networks, or from a private network to the public network.

--- a/beam/client.go
+++ b/beam/client.go
@@ -1,0 +1,58 @@
+package beam
+
+import (
+	"bytes"
+	"errors"
+	"time"
+
+	"github.com/RTradeLtd/config"
+	"github.com/RTradeLtd/rtfs"
+)
+
+// Laser is used to transfer content between two different private networks
+type Laser struct {
+	net1 *rtfs.IpfsManager
+	net2 *rtfs.IpfsManager
+}
+
+// NewLaser creates a laser client to beam content between different ipfs networks
+func NewLaser(net1Cfg, net2Cfg config.IPFS) (*Laser, error) {
+	net1, err := rtfs.NewManager(net1Cfg.APIConnection.Host+":"+net1Cfg.APIConnection.Port, nil, time.Minute*10)
+	if err != nil {
+		return nil, err
+	}
+	net2, err := rtfs.NewManager(net2Cfg.APIConnection.Host+":"+net2Cfg.APIConnection.Port, nil, time.Minute*10)
+	if err != nil {
+		return nil, err
+	}
+	return &Laser{
+		net1: net1,
+		net2: net2,
+	}, nil
+}
+
+// Beam is used to transfer content bewween two different networks
+func (l *Laser) Beam(sourceNet int, contentHash string) error {
+	switch sourceNet {
+	case 1:
+		data, err := l.net1.Cat(contentHash)
+		if err != nil {
+			return err
+		}
+		if _, err = l.net2.Add(bytes.NewReader(data)); err != nil {
+			return err
+		}
+		return nil
+	case 2:
+		data, err := l.net2.Cat(contentHash)
+		if err != nil {
+			return err
+		}
+		if _, err = l.net1.Add(bytes.NewReader(data)); err != nil {
+			return err
+		}
+		return nil
+	default:
+		return errors.New("invalid network, must be 1, or 2")
+	}
+}

--- a/beam/client_test.go
+++ b/beam/client_test.go
@@ -1,0 +1,39 @@
+package beam_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/RTradeLtd/config"
+	"github.com/RTradeLtd/rtfs"
+	"github.com/RTradeLtd/rtfs/beam"
+)
+
+func TestBeam(t *testing.T) {
+	cfg, err := config.LoadConfig("../testenv/config.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	laser, err := beam.NewLaser(cfg.IPFS, cfg.IPFS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rtfsManager, err := rtfs.NewManager(cfg.IPFS.APIConnection.Host+":"+cfg.IPFS.APIConnection.Port, nil, time.Minute*5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	file, err := os.Open("../testenv/config.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cid, err := rtfsManager.Add(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= 2; i++ {
+		if err = laser.Beam(i, cid); err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Allow people to transfer content between different IPFS networks. Primarily this will be used with Temporal's private IPFS infrastructure, allowing for the creation of "private ipfs clouds"