### PR TITLE
Allow Selection of Read-Only or Read-Write for Krab

### DIFF
--- a/krab/krab.go
+++ b/krab/krab.go
@@ -22,14 +22,18 @@ type Krab struct {
 type Opts struct {
 	Passphrase string
 	DSPath     string
+	ReadOnly   bool
 }
 
 // NewKrab is used to create a new krab ipfs keystore manager
 func NewKrab(opts Opts) (*Krab, error) {
-	ds, err := badger.NewDatastore(opts.DSPath, &badger.DefaultOptions)
+	badgerOpts := &badger.DefaultOptions
+	badgerOpts.ReadOnly = opts.ReadOnly
+	ds, err := badger.NewDatastore(opts.DSPath, badgerOpts)
 	if err != nil {
 		return nil, err
 	}
+	defer ds.Close()
 	return &Krab{
 		em: crypto.NewEncryptManager(opts.Passphrase),
 		ds: ds,

--- a/krab/krab.go
+++ b/krab/krab.go
@@ -33,7 +33,6 @@ func NewKrab(opts Opts) (*Krab, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer ds.Close()
 	return &Krab{
 		em: crypto.NewEncryptManager(opts.Passphrase),
 		ds: ds,
@@ -121,4 +120,9 @@ func (km *Krab) List() ([]string, error) {
 		ids = append(ids, strings.Split(v.Key, "/")[1])
 	}
 	return ids, nil
+}
+
+// Close is used to close our badger connection
+func (km *Krab) Close() error {
+	return km.ds.Close()
 }

--- a/krab/krab_test.go
+++ b/krab/krab_test.go
@@ -21,10 +21,11 @@ func TestKrab(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-	km, err := krab.NewKrab(krab.Opts{Passphrase: passphrase, DSPath: dsPath})
+	km, err := krab.NewKrab(krab.Opts{Passphrase: passphrase, DSPath: dsPath, ReadOnly: false})
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer km.Close()
 	// this should fail
 	if has, err := km.Has(testKeyName); err == nil {
 		t.Fatal("key was found when it shouldn't have been")


### PR DESCRIPTION
Allow the decision of whether or not access to the krab keystore is read-write or read-only