### PR TITLE
rtfs: add an IPNS resolver function

### DIFF
--- a/beam/client.go
+++ b/beam/client.go
@@ -15,11 +15,11 @@ type Laser struct {
 
 // NewLaser creates a laser client to beam content between different ipfs networks
 func NewLaser(srcURL, dstURL string) (*Laser, error) {
-	src, err := rtfs.NewManager(srcURL, nil, time.Minute*10)
+	src, err := rtfs.NewManager(srcURL, time.Minute*10)
 	if err != nil {
 		return nil, err
 	}
-	dst, err := rtfs.NewManager(dstURL, nil, time.Minute*10)
+	dst, err := rtfs.NewManager(dstURL, time.Minute*10)
 	if err != nil {
 		return nil, err
 	}

--- a/beam/client_test.go
+++ b/beam/client_test.go
@@ -19,7 +19,7 @@ func TestBeam(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rtfsManager, err := rtfs.NewManager(cfg.IPFS.APIConnection.Host+":"+cfg.IPFS.APIConnection.Port, nil, time.Minute*5)
+	rtfsManager, err := rtfs.NewManager(cfg.IPFS.APIConnection.Host+":"+cfg.IPFS.APIConnection.Port, time.Minute*5)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rtfs.go
+++ b/rtfs.go
@@ -15,12 +15,11 @@ import (
 // IpfsManager is our helper wrapper for IPFS
 type IpfsManager struct {
 	shell       *ipfsapi.Shell
-	keystore    *KeystoreManager
 	nodeAPIAddr string
 }
 
 // NewManager is used to initialize our Ipfs manager struct
-func NewManager(ipfsURL string, keystore *KeystoreManager, timeout time.Duration) (*IpfsManager, error) {
+func NewManager(ipfsURL string, timeout time.Duration) (*IpfsManager, error) {
 	// set up shell
 	sh := newShell(ipfsURL)
 	sh.SetTimeout(time.Minute * 5)
@@ -32,7 +31,6 @@ func NewManager(ipfsURL string, keystore *KeystoreManager, timeout time.Duration
 	return &IpfsManager{
 		shell:       sh,
 		nodeAPIAddr: ipfsURL,
-		keystore:    keystore,
 	}, nil
 }
 
@@ -115,16 +113,6 @@ func (im *IpfsManager) CheckPin(hash string) (bool, error) {
 
 // Publish is used for fine grained control over IPNS record publishing
 func (im *IpfsManager) Publish(contentHash, keyName string, lifetime, ttl time.Duration, resolve bool) (*ipfsapi.PublishResponse, error) {
-	if im.keystore == nil {
-		return nil, errors.New("attempting to create ipns entry with dynamic keys keystore is not enabled/generated yet")
-	}
-
-	if keyPresent, err := im.keystore.CheckIfKeyExists(keyName); err != nil {
-		return nil, err
-	} else if !keyPresent {
-		return nil, errors.New("attempting to sign with non existent key")
-	}
-
 	return im.shell.PublishWithDetails(contentHash, keyName, lifetime, ttl, resolve)
 }
 

--- a/rtfs.go
+++ b/rtfs.go
@@ -128,6 +128,11 @@ func (im *IpfsManager) Publish(contentHash, keyName string, lifetime, ttl time.D
 	return im.shell.PublishWithDetails(contentHash, keyName, lifetime, ttl, resolve)
 }
 
+// Resolve is used to resolve an IPNS hash
+func (im *IpfsManager) Resolve(hash string) (string, error) {
+	return im.shell.Resolve(hash)
+}
+
 // PubSubPublish is used to publish a a message to the given topic
 func (im *IpfsManager) PubSubPublish(topic string, data string) error {
 	if topic == "" {

--- a/rtfs.i.go
+++ b/rtfs.i.go
@@ -42,6 +42,8 @@ type Manager interface {
 	CheckPin(hash string) (bool, error)
 	// Publish is used for fine grained control over IPNS record publishing
 	Publish(contentHash, keyName string, lifetime, ttl time.Duration, resolve bool) (*ipfsapi.PublishResponse, error)
+	// Resolve is used to resolve an IPNS hash
+	Resolve(hash string) (string, error)
 	// PubSubPublish is used to publish a a message to the given topic
 	PubSubPublish(topic string, data string) error
 	// CustomRequest is used to make a custom request

--- a/rtfs_test.go
+++ b/rtfs_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 // test variables
 const (
 	testPIN             = "QmNZiPk974vDsPmQii3YbrMKfi12KTSNM7XMiYyiea4VYZ"
+	ipnsPath            = "/ipns/Qmd2GzQc68XXicmUpJZUadjsTcPUsXgP1iP1Hp6CYaY4xU"
 	testDefaultReadme   = "QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv"
 	nodeOneAPIAddr      = "192.168.1.101:5001"
 	nodeTwoAPIAddr      = "192.168.2.101:5001"
@@ -20,14 +22,14 @@ const (
 )
 
 func TestInitialize(t *testing.T) {
-	_, err := rtfs.NewManager(nodeOneAPIAddr, nil, 5*time.Minute)
+	_, err := rtfs.NewManager(nodeOneAPIAddr, 5*time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestSwarmConnect(t *testing.T) {
-	im, err := rtfs.NewManager(nodeOneAPIAddr, nil, 5*time.Minute)
+	im, err := rtfs.NewManager(nodeOneAPIAddr, 5*time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +41,7 @@ func TestSwarmConnect(t *testing.T) {
 }
 
 func TestCustomRequest(t *testing.T) {
-	im, err := rtfs.NewManager(nodeOneAPIAddr, nil, 5*time.Minute)
+	im, err := rtfs.NewManager(nodeOneAPIAddr, 5*time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +55,7 @@ func TestCustomRequest(t *testing.T) {
 }
 
 func TestPin(t *testing.T) {
-	im, err := rtfs.NewManager(nodeOneAPIAddr, nil, 5*time.Minute)
+	im, err := rtfs.NewManager(nodeOneAPIAddr, 5*time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +79,7 @@ func TestPin(t *testing.T) {
 }
 
 func TestStat(t *testing.T) {
-	im, err := rtfs.NewManager(nodeOneAPIAddr, nil, 5*time.Minute)
+	im, err := rtfs.NewManager(nodeOneAPIAddr, 5*time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +91,7 @@ func TestStat(t *testing.T) {
 }
 
 func TestDagGet(t *testing.T) {
-	im, err := rtfs.NewManager(nodeOneAPIAddr, nil, 5*time.Minute)
+	im, err := rtfs.NewManager(nodeOneAPIAddr, 5*time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +102,7 @@ func TestDagGet(t *testing.T) {
 }
 
 func TestDagPut(t *testing.T) {
-	im, err := rtfs.NewManager(nodeOneAPIAddr, nil, 5*time.Minute)
+	im, err := rtfs.NewManager(nodeOneAPIAddr, 5*time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +123,7 @@ func TestDagPut(t *testing.T) {
 }
 
 func TestNodeAddress(t *testing.T) {
-	im, err := rtfs.NewManager(nodeOneAPIAddr, nil, 5*time.Minute)
+	im, err := rtfs.NewManager(nodeOneAPIAddr, 5*time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +133,7 @@ func TestNodeAddress(t *testing.T) {
 }
 
 func TestAdd(t *testing.T) {
-	im, err := rtfs.NewManager(nodeOneAPIAddr, nil, 5*time.Minute)
+	im, err := rtfs.NewManager(nodeOneAPIAddr, 5*time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,7 +149,7 @@ func TestAdd(t *testing.T) {
 }
 
 func TestPubSub_Success(t *testing.T) {
-	im, err := rtfs.NewManager(nodeOneAPIAddr, nil, 5*time.Minute)
+	im, err := rtfs.NewManager(nodeOneAPIAddr, 5*time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +159,7 @@ func TestPubSub_Success(t *testing.T) {
 }
 
 func TestPubSub_Failure(t *testing.T) {
-	im, err := rtfs.NewManager(nodeOneAPIAddr, nil, 5*time.Minute)
+	im, err := rtfs.NewManager(nodeOneAPIAddr, 5*time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +173,7 @@ func TestPubSub_Failure(t *testing.T) {
 }
 
 func TestPatchLink(t *testing.T) {
-	im, err := rtfs.NewManager(nodeOneAPIAddr, nil, 5*time.Minute)
+	im, err := rtfs.NewManager(nodeOneAPIAddr, 5*time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,7 +201,7 @@ func TestPatchLink(t *testing.T) {
 }
 
 func TestAppendData(t *testing.T) {
-	im, err := rtfs.NewManager(nodeOneAPIAddr, nil, 5*time.Minute)
+	im, err := rtfs.NewManager(nodeOneAPIAddr, 5*time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,7 +216,7 @@ func TestAppendData(t *testing.T) {
 }
 
 func TestSetData(t *testing.T) {
-	im, err := rtfs.NewManager(nodeOneAPIAddr, nil, 5*time.Minute)
+	im, err := rtfs.NewManager(nodeOneAPIAddr, 5*time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,7 +231,7 @@ func TestSetData(t *testing.T) {
 }
 
 func TestNewObject(t *testing.T) {
-	im, err := rtfs.NewManager(nodeOneAPIAddr, nil, 5*time.Minute)
+	im, err := rtfs.NewManager(nodeOneAPIAddr, 5*time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -250,5 +252,23 @@ func TestNewObject(t *testing.T) {
 	}
 	if hash != "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn" {
 		t.Fatal("failed to generate unixfs-dir template object")
+	}
+}
+
+func TestIPNS_Publish_And_Resolve(t *testing.T) {
+	im, err := rtfs.NewManager(nodeOneAPIAddr, 5*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := im.Publish(testDefaultReadme, "self", time.Hour*24, time.Hour*24, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedHash, err := im.Resolve(resp.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Split(resolvedHash, "/")[1] != testDefaultReadme {
+		t.Fatal("failed to resolve correct hash")
 	}
 }

--- a/rtfs_test.go
+++ b/rtfs_test.go
@@ -3,7 +3,6 @@ package rtfs_test
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -269,9 +268,7 @@ func TestIPNS_Publish_And_Resolve(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Split(resolvedHash, "/")[1] != testDefaultReadme {
-		fmt.Println(resolvedHash)
-		fmt.Println(strings.Split(resolvedHash, "/")[1])
+	if strings.Split(resolvedHash, "/")[2] != testDefaultReadme {
 		t.Fatal("failed to resolve correct hash")
 	}
 }

--- a/rtfs_test.go
+++ b/rtfs_test.go
@@ -271,7 +271,7 @@ func TestIPNS_Publish_And_Resolve(t *testing.T) {
 	}
 	if strings.Split(resolvedHash, "/")[1] != testDefaultReadme {
 		fmt.Println(resolvedHash)
-		fmt.Println(strings.Split(resolvedHash, "/"))
+		fmt.Println(strings.Split(resolvedHash, "/")[1])
 		t.Fatal("failed to resolve correct hash")
 	}
 }

--- a/rtfs_test.go
+++ b/rtfs_test.go
@@ -3,6 +3,7 @@ package rtfs_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -269,6 +270,8 @@ func TestIPNS_Publish_And_Resolve(t *testing.T) {
 		t.Fatal(err)
 	}
 	if strings.Split(resolvedHash, "/")[1] != testDefaultReadme {
+		fmt.Println(resolvedHash)
+		fmt.Println(strings.Split(resolvedHash, "/"))
 		t.Fatal("failed to resolve correct hash")
 	}
 }


### PR DESCRIPTION
Adds an IPNS resolver wrapper.
Removes the built-in keystore for now as it's no longer used due to read/write count limitations with badger datastore. Eventually this will be reworked to use the gRPC instance. IPNS record publishing within Temporal also uses a customized IPFS daemon to handle publishing of records