### PR TITLE
Fix Swarm Dial Test

### DIFF
--- a/rtfs.go
+++ b/rtfs.go
@@ -184,7 +184,7 @@ func (im *IpfsManager) CustomRequest(ctx context.Context, url, commad string,
 	return resp, nil
 }
 
-// GetLogs is used to return our logger
+// GetLogs is used to return a logger for the IPFS HTTP API call log/tail
 func (im *IpfsManager) GetLogs(ctx context.Context) (ipfsapi.Logger, error) {
 	return im.shell.GetLogs(ctx)
 }

--- a/rtfs_test.go
+++ b/rtfs_test.go
@@ -16,13 +16,14 @@ import (
 
 // test variables
 const (
-	testPIN             = "QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv"
-	ipnsPath            = "/ipns/Qmd2GzQc68XXicmUpJZUadjsTcPUsXgP1iP1Hp6CYaY4xU"
-	testDefaultReadme   = "QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv"
-	testRefsHash        = "QmPS6VssQGyBYjGQSK8ordvXaU1yUoaUmTfmrV7daLeRPH"
-	nodeOneAPIAddr      = "192.168.1.101:5001"
-	nodeTwoAPIAddr      = "192.168.2.101:5001"
-	remoteNodeMultiAddr = "/ip4/172.218.49.115/tcp/4003/ipfs/QmXow5Vu8YXqvabkptQ7HddvNPpbLhXzmmU53yPCM54EQa"
+	testPIN                = "QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv"
+	ipnsPath               = "/ipns/Qmd2GzQc68XXicmUpJZUadjsTcPUsXgP1iP1Hp6CYaY4xU"
+	testDefaultReadme      = "QmS4ustL54uo8FzR9455qaxZwuMiUhyvMcX9Ba8nUH4uVv"
+	testRefsHash           = "QmPS6VssQGyBYjGQSK8ordvXaU1yUoaUmTfmrV7daLeRPH"
+	nodeOneAPIAddr         = "192.168.1.101:5001"
+	nodeTwoAPIAddr         = "192.168.2.101:5001"
+	remoteNodeOneMultiAddr = "/ip4/172.218.49.115/tcp/4003/ipfs/QmXow5Vu8YXqvabkptQ7HddvNPpbLhXzmmU53yPCM54EQa"
+	remoteNodeTwoMultiAddr = "/ip4/172.218.49.115/tcp/4002/ipfs/QmPvnFXWAz1eSghXD6JKpHxaGjbVo4VhBXY2wdBxKPbne5"
 )
 
 type args struct {
@@ -80,10 +81,12 @@ func TestSwarmConnect(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute*2)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 			defer cancel()
-			if err := im.SwarmConnect(ctx, remoteNodeMultiAddr); err != nil {
-				t.Fatal(err)
+			if err := im.SwarmConnect(ctx, remoteNodeOneMultiAddr); err != nil {
+				if err := im.SwarmConnect(ctx, remoteNodeTwoMultiAddr); err != nil {
+					t.Fatal(err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Currently one of the remote IPFS nodes is having a transient port forwarding issue that I won't be able to resolve until weekly maintenance this upcoming friday. To better handle situations like this when testing swarm dial, if the first dial attempt fails, we then attempt to dial the secondary node.